### PR TITLE
Fix PCAPReader

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,8 @@ CHANGELOG
 ---------
 
 [24.10.1]
-* add python dependency in setup.py (Cython)
+* Add python dependency in setup.py (Cython)
+* Bugfix in pcap.py (pcap_info, PCAPREADER)
 
 [1.1.1]
  * Minor fixes for doc updates

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,9 @@
 CHANGELOG
 ---------
 
+[24.10.1]
+* add python dependency in setup.py (Cython)
+
 [1.1.1]
  * Minor fixes for doc updates
 
@@ -14,4 +17,3 @@ CHANGELOG
 [1.0]
 
  * Initial commit
-

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ except ImportError:
 install_requires = (
     'steelscript>=24.2.0',
     'tzlocal',
+    'Cython'
 )
 
 
@@ -36,7 +37,7 @@ scripts = {'console_scripts': [
 
 setup_args = {
     'name':                'steelscript.packets',
-    'version':             '24.2.1',
+    'version':             '24.10.1',
     'author':              'Riverbed Technology',
     'author_email':        'eng-github@riverbed.com',
     'url':                 'http://pythonhosted.org/steelscript',

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -9,6 +9,8 @@
 from libc.stdlib cimport malloc, free
 from libc.stdint cimport uint32_t, uint64_t, uint16_t
 
+from cpython.bytes cimport PyBytes_AsString
+
 import time
 import socket
 import struct
@@ -457,7 +459,7 @@ cdef class PCAPReader(PCAPBase):
 
         fname_srt = kwargs.get('filename', '')
         fname_bytes = fname_srt.encode()
-        fname_p = fname_bytes
+        fname_p = PyBytes_AsString(input_bytes)fname_bytes)
         self.filename = fname_p
         self.have_dumper = 0
         self.reader = open_offline(self.filename, errors)

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -459,12 +459,11 @@ cdef class PCAPReader(PCAPBase):
 
         fname_srt = kwargs.get('filename', '')
         fname_bytes = fname_srt.encode()
-        fname_p = fname_bytes      
-        # self.filename = fname_p
-        self.filename = PyBytes_AsString(fname_p)
+        fname_p = PyBytes_AsString(fname_bytes)
+        self.filename = fname_srt
 
         self.have_dumper = 0
-        self.reader = open_offline(self.filename, errors)
+        self.reader = open_offline(fname_p, errors)
 
         if self.reader is NULL:
             v_err = ValueError("PCAPReader failed to open {0} for reading. "

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -459,8 +459,12 @@ cdef class PCAPReader(PCAPBase):
 
         fname_srt = kwargs.get('filename', '')
         fname_bytes = fname_srt.encode()
+
+        # Convert bytes object to char *
         fname_p = PyBytes_AsString(fname_bytes)
-        self.filename = fname_srt
+
+        # self.filename = fname_srt
+        self.filename = fname_bytes
 
         self.have_dumper = 0
         self.reader = open_offline(fname_p, errors)

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -457,10 +457,13 @@ cdef class PCAPReader(PCAPBase):
             object v_err
             str src_file
 
-        fname_srt = kwargs.get('filename', '')
-        fname_bytes = fname_srt.encode()
-        fname_p = PyBytes_AsString(fname_bytes)
-        self.filename = fname_p
+        # fname_srt = kwargs.get('filename', '')
+        # fname_bytes = fname_srt.encode()
+        # fname_p = fname_bytes      
+        # self.filename = fname_p
+
+        self.filename = fname_srt
+
         self.have_dumper = 0
         self.reader = open_offline(self.filename, errors)
 

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -462,7 +462,7 @@ cdef class PCAPReader(PCAPBase):
         # fname_p = fname_bytes      
         # self.filename = fname_p
 
-        self.filename = fname_srt
+        self.filename = PyBytes_AsString(fname_srt)
 
         self.have_dumper = 0
         self.reader = open_offline(self.filename, errors)

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -463,7 +463,7 @@ cdef class PCAPReader(PCAPBase):
         # Convert bytes object to char *
         fname_p = PyBytes_AsString(fname_bytes)
 
-        # self.filename = fname_srt
+        # Store the bytes object
         self.filename = fname_bytes
 
         self.have_dumper = 0

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -577,7 +577,7 @@ cpdef dict pcap_info(str filename):
         double first_ts
         dict rval
 
-    rdr = PCAPReader(file_name=filename)
+    rdr = PCAPReader(filename=filename)
     ts, hdr, pkt = next(rdr)
     first_ts = ts
     pkts = 1

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -458,11 +458,10 @@ cdef class PCAPReader(PCAPBase):
             str src_file
 
         fname_srt = kwargs.get('filename', '')
-        # fname_bytes = fname_srt.encode()
-        # fname_p = fname_bytes      
+        fname_bytes = fname_srt.encode()
+        fname_p = fname_bytes      
         # self.filename = fname_p
-
-        self.filename = PyBytes_AsString(fname_bytes)
+        self.filename = PyBytes_AsString(fname_p)
 
         self.have_dumper = 0
         self.reader = open_offline(self.filename, errors)

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -459,7 +459,7 @@ cdef class PCAPReader(PCAPBase):
 
         fname_srt = kwargs.get('filename', '')
         fname_bytes = fname_srt.encode()
-        fname_p = PyBytes_AsString(input_bytes)fname_bytes)
+        fname_p = PyBytes_AsString(fname_bytes)
         self.filename = fname_p
         self.have_dumper = 0
         self.reader = open_offline(self.filename, errors)

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -462,7 +462,7 @@ cdef class PCAPReader(PCAPBase):
         # fname_p = fname_bytes      
         # self.filename = fname_p
 
-        self.filename = PyBytes_AsString(fname_srt)
+        self.filename = PyBytes_AsString(fname_bytes)
 
         self.have_dumper = 0
         self.reader = open_offline(self.filename, errors)

--- a/steelscript/packets/core/pcap.pyx
+++ b/steelscript/packets/core/pcap.pyx
@@ -457,7 +457,7 @@ cdef class PCAPReader(PCAPBase):
             object v_err
             str src_file
 
-        # fname_srt = kwargs.get('filename', '')
+        fname_srt = kwargs.get('filename', '')
         # fname_bytes = fname_srt.encode()
         # fname_p = fname_bytes      
         # self.filename = fname_p


### PR DESCRIPTION
Fixing #3 
* Update to version 24.10.1
* Change file_name to filename (ValueError: PCAPReader)
* Use Cython for conversion PyBytes as *char (string)
* Add Cython missing dep